### PR TITLE
Fix SyntaxWarning from invalid escape sequence in regex

### DIFF
--- a/apply_att.py
+++ b/apply_att.py
@@ -163,7 +163,7 @@ with open(description_file, "r") as f:
         if re.match("#", line):
             continue
         else:
-            m = re.match("\s*(\S*)\s*=\s*(\S*)", line)
+            m = re.match(r"\s*(\S*)\s*=\s*(\S*)", line)
             if m:
                 data_description[m.group(1)] = m.group(2)
 


### PR DESCRIPTION
This pull request fixes a SyntaxWarning in apply_att.py caused by an invalid escape sequence in a regular expression:

`m = re.match("\s*(\S*)\s*=\s*(\S*)", line)`

Python interprets \s and \S as escape sequences, but they are not valid in regular Python strings and may cause errors in future versions. This change updates the line to use a raw string:

`m = re.match(r"\s*(\S*)\s*=\s*(\S*)", line)`

This silences the warning and ensures future compatibility with Python.